### PR TITLE
Fix website build and layout issues

### DIFF
--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: cv-layout
 title: "Curriculum Vitae"
 permalink: /cv/
 author_profile: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,5 +4,4 @@ services:
     build: .
     volumes: [.:/usr/src/app]
     ports: [4000:4000]
-    user: 1000:1000
     environment: [JEKYLL_ENV=docker]


### PR DESCRIPTION
This commit fixes two issues that were preventing the website from running correctly.

First, it resolves a Docker permission error by removing the `user` directive from the `docker-compose.yaml` file. This allows the Jekyll server to run without file access errors.

Second, it fixes a build warning on the CV page by changing the layout from `page` to the correct `cv-layout`. This ensures that the CV page renders correctly.