### PR TITLE
Update teaching experience listings

### DIFF
--- a/_pages/teaching.md
+++ b/_pages/teaching.md
@@ -4,10 +4,11 @@ title: "Teaching"
 author_profile: true
 ---
 
-My teaching interests reflect my research background in computer architecture and AI hardware systems. Topics I am prepared to teach or support include:
+## Teaching Experience
 
-- Computer architecture and hardware acceleration (graduate/advanced undergraduate level)
-- Energy-efficient AI systems and emerging architectures
-- Electrical engineering foundations informed by my M.S. training at IIT Delhi
-
-I am happy to share sample syllabi or guest lecture materials upon request.
+- FQ' 2025 — **CS178: Machine Learning and Data Mining**, Teaching Assistant
+- SQ' 2025 — **ICS51: Introduction to Computer Organization**, Teaching Assistant
+- WQ' 2025 — **CS151: Digital Logic Design**, Teaching Assistant
+- FQ' 2024 — **ICS51: Introduction to Computer Organization**, Teaching Assistant
+- WQ' 2024 — **ICS51: Introduction to Computer Organization**, Teaching Assistant
+- FQ' 2023 — **ICS32A: Python Programming with Libraries**, Teaching Assistant

--- a/index.md
+++ b/index.md
@@ -21,6 +21,9 @@ I previously earned a Master's degree in Electrical Engineering from the Indian 
 - Neurosymbolic AI
 
 ## Teaching
-- Computer architecture and hardware acceleration (graduate/advanced undergraduate level)
-- Energy-efficient AI systems and emerging architectures
-- Electrical engineering foundations informed by my M.S. training at IIT Delhi
+- FQ' 2025 — **CS178: Machine Learning and Data Mining**, Teaching Assistant
+- SQ' 2025 — **ICS51: Introduction to Computer Organization**, Teaching Assistant
+- WQ' 2025 — **CS151: Digital Logic Design**, Teaching Assistant
+- FQ' 2024 — **ICS51: Introduction to Computer Organization**, Teaching Assistant
+- WQ' 2024 — **ICS51: Introduction to Computer Organization**, Teaching Assistant
+- FQ' 2023 — **ICS32A: Python Programming with Libraries**, Teaching Assistant


### PR DESCRIPTION
### Motivation
- Replace a generic teaching-interest paragraph with an explicit quarter-by-quarter teaching experience list and keep the home page in sync for consistency.

### Description
- Replace the teaching content in `_pages/teaching.md` with a `## Teaching Experience` section that lists quarter, course, and role.
- Mirror the same updated teaching list in `index.md` so the home page displays the current teaching experience.

### Testing
- Attempted to preview the site with `bundle exec jekyll serve --host 0.0.0.0 --port 4000`, which failed because the `jekyll` executable/gem is not available.
- No other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971bfdaaec8832eb2f700cc406676ad)