### PR TITLE
Add featured talk entry with photo to Talks page

### DIFF
--- a/_pages/talks.md
+++ b/_pages/talks.md
@@ -12,3 +12,9 @@ I give research talks on topics aligned with my work in computer architecture an
 - Neurosymbolic AI
 
 If you're interested in hosting a talk, please reach out and I can share a tailored abstract.
+
+## Featured Talk
+
+![Presenting radar-vision multimodal fusion research at UC Irvine](/images/20250622_173606.jpg)
+
+I presented our work on radar-vision multimodal fusion for road user safety at UC Irvine's Calit2 Interdisciplinary Research Teams mid-program review, highlighting robust camera-radar fusion pipelines for low-light and adverse weather driving conditions.


### PR DESCRIPTION
### Motivation
- Add a featured talk entry to make a recent UC Irvine Calit2 presentation on radar-vision multimodal fusion more visible on the Talks page and include a photo.

### Description
- Appended a `## Featured Talk` section to `_pages/talks.md` that embeds the image `/images/20250622_173606.jpg` and adds a concise description of the talk.

### Testing
- No automated tests were run; the updated ` _pages/talks.md` was verified for proper markdown/front-matter structure and committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d02f4d7618832e9d32bc11d623695b)